### PR TITLE
Disabled arrow-body-style rule for node

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -71,7 +71,7 @@ module.exports = {
 
         // Do not enforce single lines when using arrow functions.
         // https://eslint.org/docs/rules/arrow-body-style
-        'arrow-body-style': 0,
+        'arrow-body-style': 'off',
         'arrow-parens': ['error', 'as-needed', {requireForBlockBody: true}],
         'implicit-arrow-linebreak': 'error',
         'no-confusing-arrow': 'error'

--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -69,14 +69,9 @@ module.exports = {
         // Throw errors for unnecessary usage of .call or .apply
         'no-useless-call': 'error',
 
-        // Arrow functions
-        // Have parens for multiple args and start on the same line
-        // .do((something, else) => {
-        //    ...many lines...
-        //  });
-        // Unless it's a very simple one-line rule
-        // .catch(err => reject(err))
-        'arrow-body-style': ['error'],
+        // Do not enforce single lines when using arrow functions.
+        // https://eslint.org/docs/rules/arrow-body-style
+        'arrow-body-style': 0,
         'arrow-parens': ['error', 'as-needed', {requireForBlockBody: true}],
         'implicit-arrow-linebreak': 'error',
         'no-confusing-arrow': 'error'

--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -5,5 +5,10 @@ module.exports = {
         node: true,
         es6: true
     },
-    extends: require.resolve('./base')
+    extends: [
+        require.resolve('./base')
+    ],
+    rules: {
+        'arrow-body-style': 0
+    }
 };

--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -5,10 +5,5 @@ module.exports = {
         node: true,
         es6: true
     },
-    extends: [
-        require.resolve('./base')
-    ],
-    rules: {
-        'arrow-body-style': 0
-    }
+    extends: require.resolve('./base')
 };


### PR DESCRIPTION
no issue

- this should not be a rule for the Ghost server side code
- this rule is not always useful for the readability
- i would like to **not** force this coding style

Reference:
https://eslint.org/docs/rules/arrow-body-style