### PR TITLE
Updated node parser version to 2017

### DIFF
--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -5,5 +5,8 @@ module.exports = {
         node: true,
         es6: true
     },
+    parserOptions: {
+        ecmaVersion: 2017
+    },
     extends: require.resolve('./base')
 };


### PR DESCRIPTION
closes #11

- node 6 is no longer supported
- bumping the parser version allows us to use async/await