### PR TITLE
Enabled `no-shadow` rule

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -70,6 +70,8 @@ module.exports = {
         'no-useless-call': 'error',
         // Don't allow console.* calls
         'no-console': 'error',
+        // Prevent [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing)
+        'no-shadow': ['warn'],
 
         // Do not enforce single lines when using arrow functions.
         // https://eslint.org/docs/rules/arrow-body-style


### PR DESCRIPTION
Prevents [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing)

Start as a warning for now and when the number of instances gets low, will upgrade to error