### PR TITLE
Added no-limit-all custom rule to help prevent accidental `limit: 'all'` in API queries

### DIFF
--- a/lib/config/base.js
+++ b/lib/config/base.js
@@ -85,6 +85,9 @@ module.exports = {
         'arrow-body-style': 'off',
         'arrow-parens': ['error', 'as-needed', {requireForBlockBody: true}],
         'implicit-arrow-linebreak': 'error',
-        'no-confusing-arrow': 'error'
+        'no-confusing-arrow': 'error',
+
+        // Prevent ?limit=all queries
+        'ghost/ghost-custom/ghost-tpl-usage': ['error']
     }
 };

--- a/lib/custom/index.js
+++ b/lib/custom/index.js
@@ -4,6 +4,7 @@ module.exports = {
         'max-api-complexity': require('./rules/max-api-complexity'),
         'no-native-error': require('./rules/no-native-error'),
         'ghost-error-usage': require('./rules/ghost-error-usage'),
-        'ghost-tpl-usage': require('./rules/ghost-tpl-usage')
+        'ghost-tpl-usage': require('./rules/ghost-tpl-usage'),
+        'no-limit-all': require('./rules/no-limit-all')
     }
 };

--- a/lib/custom/rules/no-limit-all.js
+++ b/lib/custom/rules/no-limit-all.js
@@ -1,0 +1,28 @@
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Enforce performant use of Ghost API',
+            category: 'Ghost',
+            recommended: true
+        },
+        messages: {
+            noLimitAll: '"limit=all" in API requests can cause performance issues. Are you sure you need this?'
+        }
+    },
+    create(context) {
+        return {
+            Property(node) {
+                if (
+                    node.key?.name === 'limit' &&
+                    node.value?.type === 'Literal' &&
+                    node.value?.value === 'all'
+                ) {
+                    context.report({
+                        node: node,
+                        messageId: 'noLimitAll'
+                    });
+                }
+            }
+        };
+    }
+};

--- a/test/no-limit-all.test.js
+++ b/test/no-limit-all.test.js
@@ -1,0 +1,14 @@
+const {RuleTester} = require('eslint');
+const noLimitAllRule = require('../lib/custom/rules/no-limit-all');
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-limit-all', noLimitAllRule, {
+    valid: [{
+        code: 'query = {limit: 1}'
+    }],
+    invalid: [{
+        code: 'query = {limit: \'all\'}',
+        // we can use messageId from the rule object
+        errors: [{messageId: 'noLimitAll'}]
+    }]
+});


### PR DESCRIPTION
no issue

- errors if `limit: 'all'` key/value pair is used
