### PR TITLE
Updated eslint-plugin-filenames to a fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@kapouer/eslint-plugin-no-return-in-loop": "1.0.0",
     "eslint-plugin-ember": "11.5.2",
-    "eslint-plugin-filenames": "1.3.2",
+    "eslint-plugin-filenames": "allouis/eslint-plugin-filenames",
     "eslint-plugin-mocha": "7.0.1",
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,10 +690,9 @@ eslint-plugin-es@^4.1.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
-eslint-plugin-filenames@1.3.2:
+eslint-plugin-filenames@allouis/eslint-plugin-filenames:
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
-  integrity sha512-tqxJTiEM5a0JmRCUYQmxw23vtTxrb2+a3Q2mMOPhFxvt7ZQQJmdiuMby9B/vUAuVMghyP7oET+nIf6EO6CBd/w==
+  resolved "https://codeload.github.com/allouis/eslint-plugin-filenames/tar.gz/faf1b6b0c5c00ce963724dfb40f5a32de2d88d3d"
   dependencies:
     lodash.camelcase "4.3.0"
     lodash.kebabcase "4.1.1"


### PR DESCRIPTION
This package is unmaintained and we wanted to add some new rules so that we can better enforce filenaming conventions in Ghost. The changes are backwards compatible for the existing rules, only adding an extra option to match-regex.

The changeset from the original package at the time of writing is in:
https://github.com/allouis/eslint-plugin-filenames/commit/a59e08330f606