### PR TITLE
Updated node eslint config to lint filenames

### DIFF
--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -24,7 +24,9 @@ module.exports = {
         ]],
         'ghost/ghost-custom/no-native-error': ['error'],
         'ghost/ghost-custom/ghost-error-usage': ['error'],
-        'ghost/ghost-custom/ghost-tpl-usage': ['error']
+        'ghost/ghost-custom/ghost-tpl-usage': ['error'],
+        'ghost/filenames/match-exported-class': ['error', null, true],
+        'ghost/filenames/match-regex': ['error', '^[a-z0-9-.]+$', null, true]
     },
     overrides: [
         {


### PR DESCRIPTION
- All files must be kebab-case
- Unless they export a class, then they must be PascalCase and match the class name