### PR TITLE
Switched to `eslint-plugin-filenames-ts`

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -5,7 +5,7 @@ const mocha = require('eslint-plugin-mocha');
 const node = require('eslint-plugin-n');
 const unicorn = require('eslint-plugin-unicorn');
 const sortImportsES6Autofix = require('eslint-plugin-sort-imports-es6-autofix');
-const filenames = require('eslint-plugin-filenames');
+const filenames = require('eslint-plugin-filenames-ts');
 const noReturnInLoop = require('@kapouer/eslint-plugin-no-return-in-loop');
 const custom = require('./custom');
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@typescript-eslint/eslint-plugin": "8.33.0",
     "@typescript-eslint/parser": "8.33.0",
     "eslint-plugin-ember": "12.5.0",
-    "eslint-plugin-filenames": "allouis/eslint-plugin-filenames#15dc354f4e3d155fc2d6ae082dbfc26377539a18",
+    "eslint-plugin-filenames-ts": "1.3.2",
     "eslint-plugin-mocha": "7.0.1",
     "eslint-plugin-n": "17.18.0",
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,10 +505,10 @@ eslint-plugin-es-x@^7.8.0:
     "@eslint-community/regexpp" "^4.11.0"
     eslint-compat-utils "^0.5.1"
 
-eslint-plugin-filenames@allouis/eslint-plugin-filenames#15dc354f4e3d155fc2d6ae082dbfc26377539a18:
+eslint-plugin-filenames-ts@1.3.2:
   version "1.3.2"
-  uid "15dc354f4e3d155fc2d6ae082dbfc26377539a18"
-  resolved "https://codeload.github.com/allouis/eslint-plugin-filenames/tar.gz/15dc354f4e3d155fc2d6ae082dbfc26377539a18"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-filenames-ts/-/eslint-plugin-filenames-ts-1.3.2.tgz#06be818d3494f0f2a298ac044f495beb81fe2e5d"
+  integrity sha512-ZgcMHTYL4JXBmvbUYAyNeqKIwC038v6Jru+FxJlZ2vk3XOaWIiFphcjbVS/7bdIRADMnXYI8xfgY9g/xtIoDVw==
   dependencies:
     lodash.camelcase "4.3.0"
     lodash.kebabcase "4.1.1"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PROD-1899

We forked the unmaintained eslint-plugin-filenames package in 2023 to add some extra features and to support typescript interfaces. This change migrates the dependency from a git dependency to an npm dependency.