### PR TITLE
Added ESLint 9 flat config compatibility for filenames/match-regex and filenames/no-index rules

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -20,6 +20,17 @@ const plugins = {
     'ghost-custom': custom
 };
 
+// Schemas for rules that don't define them (needed for ESLint 9 flat config)
+// Note: match-regex options allow null values (e.g., ['error', '^pattern$', null, true])
+const ruleSchemas = {
+    'filenames/match-regex': [
+        {type: 'string'},
+        {type: ['boolean', 'null']},
+        {type: ['boolean', 'null']}
+    ],
+    'filenames/no-index': []
+};
+
 /**
  * Create a rules object from plugin rules.
  * Each rule is prefixed by the name of the plugin it comes from
@@ -32,7 +43,19 @@ const getPrefixedPluginRules = () => {
 
         Object.keys(rules).forEach((rule) => {
             let name = `${plugin}/${rule}`;
-            prefixedRules[name] = rules[rule];
+            let ruleDefinition = rules[rule];
+
+            // Wrap function-style rules to add missing schemas for ESLint 9 compatibility
+            if (typeof ruleDefinition === 'function' && ruleSchemas[name]) {
+                prefixedRules[name] = {
+                    create: ruleDefinition,
+                    meta: {
+                        schema: ruleSchemas[name]
+                    }
+                };
+            } else {
+                prefixedRules[name] = ruleDefinition;
+            }
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-ghost",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Shared eslint configurations",
   "author": "Ghost Foundation",
   "homepage": "https://github.com/TryGhost/eslint-plugin-ghost",

--- a/test/filenames-schema.test.js
+++ b/test/filenames-schema.test.js
@@ -1,0 +1,33 @@
+const assert = require('node:assert/strict');
+const {test} = require('node:test');
+const {getPrefixedPluginRules} = require('../lib/plugins');
+
+const rules = getPrefixedPluginRules();
+
+test('filenames/match-regex should be an object-style rule with schema', function () {
+    const rule = rules['filenames/match-regex'];
+
+    assert.equal(typeof rule, 'object');
+    assert.equal(typeof rule.create, 'function');
+    assert.ok(rule.meta, 'rule should have meta property');
+    assert.ok(Array.isArray(rule.meta.schema), 'rule should have meta.schema array');
+
+    const schema = rule.meta.schema;
+
+    // Option 1: regex pattern string
+    assert.deepEqual(schema[0], {type: 'string'});
+    // Option 2: ignoreExporting (boolean or null)
+    assert.deepEqual(schema[1], {type: ['boolean', 'null']});
+    // Option 3: ignoreExportingClass (boolean or null)
+    assert.deepEqual(schema[2], {type: ['boolean', 'null']});
+});
+
+test('filenames/no-index should be an object-style rule with empty schema', function () {
+    const rule = rules['filenames/no-index'];
+
+    assert.equal(typeof rule, 'object');
+    assert.equal(typeof rule.create, 'function');
+    assert.ok(rule.meta, 'rule should have meta property');
+    assert.ok(Array.isArray(rule.meta.schema), 'rule should have meta.schema array');
+    assert.equal(rule.meta.schema.length, 0, 'no-index takes no options');
+});

--- a/test/filenames-schema.test.js
+++ b/test/filenames-schema.test.js
@@ -1,8 +1,14 @@
 const assert = require('node:assert/strict');
 const {test} = require('node:test');
 const {getPrefixedPluginRules} = require('../lib/plugins');
+const filenamesPackage = require('eslint-plugin-filenames-ts/package.json');
 
 const rules = getPrefixedPluginRules();
+
+test('eslint-plugin-filenames-ts version check', function () {
+    assert.equal(filenamesPackage.version, '1.3.2',
+        'eslint-plugin-filenames-ts version changed - verify schemas in lib/plugins.js are still correct or if the plugin now provides its own');
+});
 
 test('filenames/match-regex should be an object-style rule with schema', function () {
     const rule = rules['filenames/match-regex'];


### PR DESCRIPTION
**what**

* Adds JSON schema definitions for filenames/match-regex and filenames/no-index rules from eslint-plugin-filenames-ts to enable ESLint 9 flat config compatibility
* Update is backwards compatible: The object-style {meta, create} rule format [has been supported by ESLint 5+](https://github.com/eslint/eslint/blob/v5.11.0/lib/testers/rule-tester.js#L302) (our peer dependency).

**why**

* The eslint-plugin-filenames-ts package exports rules as plain functions without meta.schema definitions. ESLint 9's flat config requires schemas for option validation, otherwise it throws errors when rules are configured with options.

* This fix wraps the function-style rules with object-style definitions that include the expected schemas, allowing configurations like `['error', '^[a-z0-9.-]+$', false]` to work with ESLint 9.

**note:**  [eslint filenames plugin is no longer actively maintained](https://www.npmjs.com/package/eslint-plugin-filenames-ts), so we might switch to something else if needed later. 
